### PR TITLE
Fixed PDU prefix for PDUServerIdentification

### DIFF
--- a/client/src/fsd/pdu/pdu_server_identification.h
+++ b/client/src/fsd/pdu/pdu_server_identification.h
@@ -31,7 +31,7 @@ public:
 
     static PDUServerIdentification fromTokens(const QStringList& fields);
 
-    static QString pdu() { return "#DI"; }
+    static QString pdu() { return "$DI"; }
 
     QString Version;
     QString InitialChallengeKey;


### PR DESCRIPTION
Prefix was `#DI` but should be `$DI`