### PR TITLE
Possible fix for the altitude offset of other AC in XP12

### DIFF
--- a/client/src/aircrafts/user_aircraft_data.h
+++ b/client/src/aircrafts/user_aircraft_data.h
@@ -31,6 +31,7 @@ public:
     double AltitudeAglM;
     double AltitudePressure;
     double BarometerSeaLevel;
+    double AltimeterTemperatureError;
     double GroundSpeed;
     double Pitch;
     double Heading;
@@ -51,6 +52,7 @@ public:
                 AltitudeAglM != other.AltitudeAglM ||
                 AltitudePressure != other.AltitudePressure ||
                 BarometerSeaLevel != other.BarometerSeaLevel ||
+                AltimeterTemperatureError != other.AltimeterTemperatureError ||
                 GroundSpeed != other.GroundSpeed ||
                 Pitch != other.Pitch ||
                 Heading != other.Heading ||
@@ -72,6 +74,7 @@ public:
                 AltitudeAglM == other.AltitudeAglM &&
                 AltitudePressure == other.AltitudePressure &&
                 BarometerSeaLevel == other.BarometerSeaLevel &&
+                AltimeterTemperatureError == other.AltimeterTemperatureError &&
                 GroundSpeed == other.GroundSpeed &&
                 Pitch == other.Pitch &&
                 Heading == other.Heading &&

--- a/client/src/network/networkmanager.cpp
+++ b/client/src/network/networkmanager.cpp
@@ -547,7 +547,7 @@ namespace xpilot
 
         if(IsXplane12())
         {
-            m_altitudeDelta = CalculatePressureAltitude() - m_userAircraftData.AltitudePressure;
+            m_altitudeDelta = m_userAircraftData.AltimeterTemperatureError;
         }
         else
         {
@@ -609,7 +609,7 @@ namespace xpilot
                                            NetworkRating::OBS,
                                            m_userAircraftData.Latitude,
                                            m_userAircraftData.Longitude,
-                                           (m_userAircraftData.AltitudeMslM * 3.28084) - m_altitudeDelta,
+                                           (m_userAircraftData.AltitudeMslM * 3.28084) + m_altitudeDelta,
                                            GetPressureAltitude(),
                                            m_userAircraftData.GroundSpeed,
                                            m_userAircraftData.Pitch,
@@ -626,7 +626,7 @@ namespace xpilot
                                                m_connectInfo.Callsign,
                                                m_userAircraftData.Latitude,
                                                m_userAircraftData.Longitude,
-                                               m_userAircraftData.AltitudeMslM * 3.28084,
+                                               (m_userAircraftData.AltitudeMslM * 3.28084) + m_altitudeDelta,
                                                m_userAircraftData.AltitudeAglM * 3.28084,
                                                m_userAircraftData.Pitch,
                                                m_userAircraftData.Heading,
@@ -648,7 +648,7 @@ namespace xpilot
                                                m_connectInfo.Callsign,
                                                m_userAircraftData.Latitude,
                                                m_userAircraftData.Longitude,
-                                               m_userAircraftData.AltitudeMslM * 3.28084,
+                                               (m_userAircraftData.AltitudeMslM * 3.28084) + m_altitudeDelta,
                                                m_userAircraftData.AltitudeAglM * 3.28084,
                                                m_userAircraftData.Pitch,
                                                m_userAircraftData.Heading,
@@ -671,7 +671,7 @@ namespace xpilot
                                                m_connectInfo.Callsign,
                                                m_userAircraftData.Latitude,
                                                m_userAircraftData.Longitude,
-                                               m_userAircraftData.AltitudeMslM * 3.28084,
+                                               (m_userAircraftData.AltitudeMslM * 3.28084) + m_altitudeDelta,
                                                m_userAircraftData.AltitudeAglM * 3.28084,
                                                m_userAircraftData.Pitch,
                                                m_userAircraftData.Heading,
@@ -959,11 +959,11 @@ namespace xpilot
             return altitude;
         }
 
-        if(m_userAircraftData.AltitudePressure < 0) {
-            return altitude;
-        }
+        // sim/flightmodel/position/elevation is true altitude corrected for temperature
+        // for comparison we need to add the error back in 
+        double userTrueAltitude = m_userAircraftData.AltitudeMslM * 3.28084 + m_userAircraftData.AltimeterTemperatureError;
 
-        double verticalDistance = std::abs(m_userAircraftData.AltitudePressure - altitude);
+        double verticalDistance = std::abs(userTrueAltitude - altitude);
         if(verticalDistance > 6000.0) {
             return altitude;
         }
@@ -973,7 +973,7 @@ namespace xpilot
             weight = 1.0 - ((verticalDistance - 3000.0) / 3000.0);
         }
 
-        double offset = m_userAircraftData.AltitudePressure - (m_userAircraftData.AltitudeMslM * 3.28084);
-        return altitude - (offset * weight);
+        // Network altitude is uncorrected, we need to substract the error
+        return altitude - (m_userAircraftData.AltimeterTemperatureError * weight);
     }
 }

--- a/client/src/simulator/xplane_adapter.cpp
+++ b/client/src/simulator/xplane_adapter.cpp
@@ -61,6 +61,7 @@ enum DataRef
     AltitudeAgl,
     AltitudePressure,
     BarometerSeaLevel,
+    AltimeterTemperatureError,
     GroundSpeed,
     Pitch,
     Heading,
@@ -285,6 +286,7 @@ void XplaneAdapter::SubscribeDataRefs()
     SubscribeDataRef("sim/flightmodel/position/y_agl", DataRef::AltitudeAgl, 5);
     SubscribeDataRef("sim/flightmodel2/position/pressure_altitude", DataRef::AltitudePressure, 5);
     SubscribeDataRef("sim/weather/barometer_sealevel_inhg", DataRef::BarometerSeaLevel, 5);
+    SubscribeDataRef("sim/weather/aircraft/altimeter_temperature_error", DataRef::AltimeterTemperatureError, 5);
     SubscribeDataRef("sim/flightmodel/position/theta", DataRef::Pitch, 5);
     SubscribeDataRef("sim/flightmodel/position/psi", DataRef::Heading, 5);
     SubscribeDataRef("sim/flightmodel/position/phi", DataRef::Bank, 5);
@@ -561,6 +563,9 @@ void XplaneAdapter::OnDataReceived()
                     break;
                 case DataRef::BarometerSeaLevel:
                     m_userAircraftData.BarometerSeaLevel = value * 33.8639; // inHg to millibar
+                    break;
+                case DataRef::AltimeterTemperatureError:
+                    m_userAircraftData.AltimeterTemperatureError = value;
                     break;
                 case DataRef::LatitudeVelocity:
                     m_userAircraftData.LatitudeVelocity = value * -1.0;


### PR DESCRIPTION
Not sure if it makes any sense. I don't have a qt environment, so I wasn't able to compile and test.

I also added the offset for the Send*FastPositionPacket functions, but that's only a wild guess.