### PR TITLE
Convert Git submodules to HTTPS URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "client/afv-native"]
-	path = client/afv-native
-	url = git@github.com:xpilot-project/afv-native.git
+       path = client/afv-native
+       url = https://github.com/xpilot-project/afv-native
 [submodule "plugin/3rdparty/XPMP2"]
-	path = plugin/3rdparty/XPMP2
-	url = git@github.com:xpilot-project/XPMP2.git
+       path = plugin/3rdparty/XPMP2
+       url = https://github.com/xpilot-project/XPMP2
 [submodule "plugin/3rdparty/imgui"]
-	path = plugin/3rdparty/imgui
-	url = git@github.com:ocornut/imgui.git
+       path = plugin/3rdparty/imgui
+       url = https://github.com/ocornut/imgui
 [submodule "dependencies"]
-	path = dependencies
-	url = git@github.com:xpilot-project/dependencies.git
+       path = dependencies
+       url = https://github.com/xpilot-project/dependencies


### PR DESCRIPTION
Convert Git submodule URLs to HTTPS.

This is because, when cloning this project over HTTPS, Git gets 'permission denied' errors when it tries to initialise the submodules.