### PR TITLE
added missing QVariant include

### DIFF
--- a/client/src/audio/notification_sound_engine.h
+++ b/client/src/audio/notification_sound_engine.h
@@ -8,6 +8,7 @@
 #include <QAudioDevice>
 #include <QList>
 #include <QString>
+#include <QVariant>
 
 namespace xpilot {
 


### PR DESCRIPTION
I ran into a compilation error because this include was missing:

`client/src/audio/notification_sound_engine.h:46:9: error: return type ‘class QVariant’ is incomplete`

This simple patch fixes it.